### PR TITLE
fix(security): add rel=noopener noreferrer to navbar GitHub link

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -66,6 +66,7 @@
 			<a
 				href="https://github.com/lucasew/base16-showcase"
 				target="_blank"
+				rel="noopener noreferrer"
 				class="btn btn-square btn-ghost"
 				aria-label="Github"
 			>


### PR DESCRIPTION
## Problem

The navbar GitHub link uses `target="_blank"` without `rel="noopener noreferrer"`. A page opened that way can reach `window.opener` and redirect the original tab (reverse tabnabbing).

## Change

Add `rel="noopener noreferrer"` on the external GitHub anchor in `src/routes/+layout.svelte`. No other layout changes.

## Verify

- Diff is a single attribute on the existing link
- Manual sanity check: link still points at `https://github.com/lucasew/base16-showcase` with `target="_blank"`

## Finding

`layout-noopener` — security low hanging fruit