### PR TITLE
fix(csp): allow Sentry US ingest in connect-src

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -20,7 +20,9 @@ const config = {
 				'script-src': ["'self'"],
 				'style-src': ["'self'", "'unsafe-inline'"],
 				'img-src': ["'self'"],
-				'connect-src': ["'self'"],
+				// Allow browser SDK envelopes to the project DSN host (US region).
+				// See src/hooks.client.ts — without this, CSP silently drops Sentry reports.
+				'connect-src': ["'self'", 'https://*.ingest.us.sentry.io'],
 				'base-uri': ["'self'"],
 				'object-src': ["'none'"]
 			}


### PR DESCRIPTION
## Problem

Sentry is wired up in `src/hooks.client.ts` with a US-region DSN (`*.ingest.us.sentry.io`), but kit CSP `connect-src` only allowed `'self'`. The browser blocks outbound envelopes, so client error reporting never leaves the page even though Sentry is initialized.

## Change

- Extend `connect-src` with `https://*.ingest.us.sentry.io` (matches this project's DSN host shape).
- Leave nonce mode and every other directive alone.

## Warning — intentional network policy change

This **deliberately** lets the browser open outbound connections to Sentry's US ingest hosts. That is required for the existing Sentry integration to work. If outbound third-party telemetry is not wanted, drop Sentry instead of re-tightening `connect-src` alone.

## Verify

- Config loads with updated `connect-src`
- `bun run check` — 0 errors / 0 warnings

Finding: `csp-sentry-connect-src`