### PR TITLE
fix(types): align app.d.ts with paraglide-js v2

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,13 +1,12 @@
-// src/app.d.ts
-import type { AvailableLanguageTag } from '$lib/paraglide/runtime';
-import type { ParaglideLocals } from '@inlang/paraglide-sveltekit';
-
+// See https://svelte.dev/docs/kit/types#app.d.ts
+// for information about these interfaces
 declare global {
 	namespace App {
-		interface Locals {
-			paraglide: ParaglideLocals<AvailableLanguageTag>;
-		}
-		// ...
+		// interface Error {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface PageState {}
+		// interface Platform {}
 	}
 }
 


### PR DESCRIPTION
## Problem

`src/app.d.ts` still typed `App.Locals.paraglide` with symbols from the old paraglide-sveltekit stack:

- `AvailableLanguageTag` from `$lib/paraglide/runtime` (runtime exports `Locale`, not that name)
- `ParaglideLocals` from `@inlang/paraglide-sveltekit` (not a dependency; package is `@inlang/paraglide-js`)

Nothing in the app reads `event.locals.paraglide`. Hooks use `paraglideMiddleware` and only rewrite the request / `%paraglide.lang%` placeholder.

## Change

Replace the stale Locals typing with the default empty SvelteKit `App` namespace scaffold. Types match what the app actually uses.

## Verify

- `bun run check` — 0 errors, 0 warnings