### PR TITLE
fix(themes): use store auto-subscription in Themes.svelte

### DIFF
--- a/src/lib/components/Themes.svelte
+++ b/src/lib/components/Themes.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
-	import type { Maybe, Theme } from '$lib/Model';
 	import themeStore from '$lib/stores/themes';
 	import ThemeCard from '$lib/components/ThemeCard.svelte';
-
-	let themes: Maybe<Record<string, Theme>> = null;
-
-	themeStore.subscribe((_themes) => {
-		themes = _themes;
-	});
 </script>
 
-{#if themes}
+{#if $themeStore}
 	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-		{#each Object.entries(themes) as [id, theme] (id)}
+		{#each Object.entries($themeStore) as [id, theme] (id)}
 			<ThemeCard {theme} {id} />
 		{/each}
 	</div>


### PR DESCRIPTION
## Summary

`Themes.svelte` called `themeStore.subscribe` without keeping the unsubscribe handle, so every remount left another live subscription.

It now uses `$themeStore`, same pattern as `+page.svelte`. Svelte owns subscribe/unsubscribe; the local `themes` mirror is gone.

## Why

- Manual subscribe without cleanup leaks on remount
- Auto-subscription is the intended store API in this codebase already

## Test plan

- [x] `bun run check` — 0 errors, 0 warnings
- [ ] Load default themes and confirm the ThemeCard grid still renders
- [ ] Drop themes / navigate away and back — no duplicate subscription buildup

finding-id: themes-auto-subscribe